### PR TITLE
Extra paths to check for windbg

### DIFF
--- a/dsDebuggingToolsPath_sISA.py
+++ b/dsDebuggingToolsPath_sISA.py
@@ -21,6 +21,7 @@ sProgramFilesPath_x64 = os.getenv("ProgramW6432");
 dasPotentialDebuggingToolsPaths_sISA["x86"].extend([
   os.path.join(sProgramFilesPath_x86, "Windows Kits", "10", "Debuggers", "x86"),
   os.path.join(sProgramFilesPath_x86, "Windows Kits", "8.1", "Debuggers", "x86"),
+  os.path.join(sProgramFilesPath_x86, "Debugging Tools for Windows (x86)"),
 ]);
 if sOSISA == "x64":
   dasPotentialDebuggingToolsPaths_sISA["x64"].extend([
@@ -28,6 +29,7 @@ if sOSISA == "x64":
     os.path.join(sProgramFilesPath_x64, "Windows Kits", "8.1", "Debuggers", "x64"),
     os.path.join(sProgramFilesPath_x86, "Windows Kits", "10", "Debuggers", "x64"),
     os.path.join(sProgramFilesPath_x86, "Windows Kits", "8.1", "Debuggers", "x64"),
+    os.path.join(sProgramFilesPath_x64, "Debugging Tools for Windows (x64)"),    
   ]);
 
 dsDebuggingToolsPath_sISA = {};


### PR DESCRIPTION
Add defaults path from dbg_x86.msi and dbg_amd64.msi installers

I usually install this windbg package to avoid having to download the SDK installer, cBugId was not detecting the default path.

http://download.microsoft.com/download/A/6/A/A6AC035D-DA3F-4F0C-ADA4-37C8E5D34E3D/setup/WinSDKDebuggingTools/dbg_x86.msi
http://download.microsoft.com/download/A/6/A/A6AC035D-DA3F-4F0C-ADA4-37C8E5D34E3D/setup/WinSDKDebuggingTools_amd64/dbg_amd64.msi